### PR TITLE
Remove second server instance on port 8081

### DIFF
--- a/frontend/timer.html
+++ b/frontend/timer.html
@@ -192,7 +192,7 @@
 				isRunning: false
 			};
 
-			const socket = new WebSocket(`ws://${window.location.host.replace("8080", "8081")}/ws`);
+			const socket = new WebSocket(`ws://${window.location.host}/ws`);
 
 			socket.onmessage = function(event) {
 				const data = JSON.parse(event.data);


### PR DESCRIPTION
After learning a bit more about web sockets, I found out that we don't need to have the api and web sockets server on separate ports. This PR removes the server on port 8081 and moves the web socket handler onto port 8080 with the other api handlers. 

This PR closes issue #14.